### PR TITLE
Fix by_string() panic on empty string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,25 +222,30 @@ impl Color {
     ///
     /// **NOTE:** Return `Result<[u8;3],u16>` as color data `[u8;3]` or Not found (`404`).
     pub fn by_string(&self, color: String) -> Result<[u8; 3], u16> {
-        let mut got = false;
-        let mut col = [0, 0, 0];
-        for c in colors_array::COLORS_DATA.iter() {
-            if String::from(c.0)
-                == format!(
-                    "{}{}",
-                    &color.trim().to_uppercase()[0..1],
-                    &color.trim().to_lowercase()[1..]
-                )
-            {
-                col = (c.1).to_owned();
-                got = true;
-                break;
-            }
-        }
-        if got {
-            Ok(col)
-        } else {
+        // if there ends up being a color whose name is the empty string, this will need changing
+        if color.len() == 0 {
             Err(404)
+        } else {
+            let mut got = false;
+            let mut col = [0, 0, 0];
+            for c in colors_array::COLORS_DATA.iter() {
+                if String::from(c.0)
+                    == format!(
+                        "{}{}",
+                        &color.trim().to_uppercase()[0..1],
+                        &color.trim().to_lowercase()[1..]
+                    )
+                {
+                    col = (c.1).to_owned();
+                    got = true;
+                    break;
+                }
+            }
+            if got {
+                Ok(col)
+            } else {
+                Err(404)
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,8 @@ mod test {
 
     #[test]
     fn test_color__by_string_fn() {
+        assert_eq!(Color::val().by_string(String::from("")), Err(404));
+        assert_eq!(Color::val().by_string(String::from("A")), Err(404));
         assert_eq!(
             Color::val()
                 .by_string(String::from("Azure"))


### PR DESCRIPTION
This is a weird edge case I encountered when trying to write a color parser using `nom`. Because of how it handles capitalization, `by_string()` panics due to an index-out-of-bounds error when given an empty string. I added a test for this case and added a length check to `by_string()`. (I wasn't sure if I should increment the version number for this.)